### PR TITLE
DockerfileをCloud Run用に変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ ADD Gemfile.lock $APP_HOME/Gemfile.lock
 ENV BUNDLE_DISABLE_SHARED_GEMS 1
 RUN bundle install -j4
 
-CMD ["bundle", "exec", "rails", "server", "--port", "3000"]
+CMD ["bundle", "exec", "rails", "server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,11 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - \
     && apt-get update -qq \
     && apt-get install -y build-essential nodejs postgresql-client git
 
-ENV APP_HOME /var/src/app
-RUN mkdir -p $APP_HOME
-WORKDIR $APP_HOME
-ADD Gemfile $APP_HOME/Gemfile
-ADD Gemfile.lock $APP_HOME/Gemfile.lock
+COPY Gemfile Gemfile.lock /
+RUN bundle install
 
-ENV BUNDLE_DISABLE_SHARED_GEMS 1
-RUN bundle install -j4
+WORKDIR /app
+
+COPY . .
 
 CMD ["bundle", "exec", "rails", "server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,3 +15,5 @@ ADD Gemfile.lock $APP_HOME/Gemfile.lock
 
 ENV BUNDLE_DISABLE_SHARED_GEMS 1
 RUN bundle install -j4
+
+CMD ["bundle", "exec", "rails", "server", "--port", "3000"]

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -9,7 +9,7 @@ threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetcth("PORT")
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -9,7 +9,7 @@ threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetcth("PORT")
+port        ENV.fetcth("PORT") {}
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -9,7 +9,7 @@ threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetcth("PORT") {}
+port        ENV.fetch("PORT") {}
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
## 概要
プロジェクト全体をbuild用のcontainerに再帰的にコピーをさせるようにする。

## 要件・仕様
Cloud Run用にDockerfileを変更する

## 動作確認
```
% docker build
% docker run
```
ができる